### PR TITLE
Feature/byby fjct

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ To propose a new code example, create a Issues.
 
 ## Copyright and License
 
-All content in this repository, unless otherwise stated, is Copyright © FUJITSU CLOUD TECHNOLOGIES LIMITED, Inc. or its affiliates. All rights reserved.
+All content in this repository, unless otherwise stated, is Copyright © Fujitsu. or its affiliates. All rights reserved.
 
 Except where otherwise noted, all examples in this collection are licensed under the Apache license, version 2.0 (the "License"). The full license text is provided in the LICENSE file accompanying this repository.

--- a/python/README.md
+++ b/python/README.md
@@ -15,4 +15,4 @@ Code examples that show how to use Boto3 to access nifcloud.
 - [nifcloud SDK for Python Documentation](https://nifcloud-sdk-python.readthedocs.io/en/latest/)
 
 
-Copyright nifcloud, Inc. All Rights Reserved.
+Copyright Fujitsu. All Rights Reserved.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -10,4 +10,5 @@
 - [Terraform Website](https://terraform.io)
 - [NIFCLOUD Provider Documentation](https://github.com/nifcloud/terraform-provider-nifcloud/blob/master/docs/index.md)
 - [NIFCLOUD Provider Examples](https://github.com/nifcloud/terraform-provider-nifcloud/blob/master/examples/)
-Copyright nifcloud, Inc. All Rights Reserved.
+
+Copyright Fujtisu. All Rights Reserved.

--- a/terraform/demo/README.md
+++ b/terraform/demo/README.md
@@ -1,6 +1,6 @@
 # Terraform Demo
 
-This is a simple terraform demo for [NIFCLOUD](https://www.nifcloud.com/)  
+This is a simple terraform demo for [NIFCLOUD](https://pfs.nifcloud.com/)  
 This repository uses [Terraform Provider for NIFCLOUD](https://github.com/nifcloud/terraform-provider-nifcloud)
 
 ## Usage


### PR DESCRIPTION
in April 1st 2024. FUJITSU CLOUD TECHNOLOGIES was absorption merged by Fujitsu.

so we was changed Copyrights.

"www.nifcloud.com" has been closed. Instead, we listed the service site "pfs.nifcloud.com".