### PR TITLE
update document site url

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -11,7 +11,7 @@ Code examples that show how to use Boto3 to access nifcloud.
 
 ## Documentation
 
-- [nifcloud API Documentation](https://pfs.nifcloud.com/api/)
+- [nifcloud API Documentation](https://docs.nifcloud.com/)
 - [nifcloud SDK for Python Documentation](https://nifcloud-sdk-python.readthedocs.io/en/latest/)
 
 

--- a/python/example_code/add-network_interface.py
+++ b/python/example_code/add-network_interface.py
@@ -39,7 +39,7 @@ def add_interface(client):
             # memo
             Description='string',
             # Set Ipaddress
-            # See https://pfs.nifcloud.com/api/rest/CreateNetworkInterface.htm
+            # See https://docs.nifcloud.com/cp/api/CreateNetworkInterface.htm
             IpAddress='string',
             # Connect Network
             # net-COMMON_GLOBAL :Common Global

--- a/python/example_code/create-autoscaling.py
+++ b/python/example_code/create-autoscaling.py
@@ -32,7 +32,7 @@ def create_autoscaling(client):
             # Range 1800-36000(1800step).Default 1800
             InstanceLifecycleLimit=1800,
             #Server Type.Default 'mini'
-            #see also https://pfs.nifcloud.com/api/rest/RunInstances.htm
+            #see also https://docs.nifcloud.com/cp/api/RunInstances.htm
             InstanceType="mini",
             # Min Instance count.
             # Range 1-(MaxSize-1)

--- a/python/example_code/create-l4lb-sorrypage.py
+++ b/python/example_code/create-l4lb-sorrypage.py
@@ -60,7 +60,7 @@ def create_l4lb_sorrypage(client):
                         },
                     ],
                     NetworkVolume=10,# Max Network Traffic.
-                                     # See also https://pfs.nifcloud.com/api/rest/CreateLoadBalancer.htm
+                                     # See also https://docs.nifcloud.com/cp/api/CreateLoadBalancer.htm
                     PolicyType='standard' # Encrypt type
                                           # standard: Not ATS Support(Default)
                                           # ats: ATS Support

--- a/python/example_code/create-l4lb.py
+++ b/python/example_code/create-l4lb.py
@@ -60,7 +60,7 @@ def create_l4lb(client):
                         },
                     ],
                     NetworkVolume=10,# Max Network Traffic.
-                                     # See also https://pfs.nifcloud.com/api/rest/CreateLoadBalancer.htm
+                                     # See also https://docs.nifcloud.com/cp/api/CreateLoadBalancer.htm
                     PolicyType='standard' # Encrypt type
                                           # standard: Not ATS Support(Default)
                                           # ats: ATS Support

--- a/python/example_code/create-multilb.py
+++ b/python/example_code/create-multilb.py
@@ -109,7 +109,7 @@ def create_multi_lb(client):
             NetworkInterface=[
                 {
                     'IpAddress': 'string',#See also NetworkInterface.n.IpAddress in
-                                          #https://pfs.nifcloud.com/api/rest/NiftyCreateElasticLoadBalancer.htm
+                                          #https://docs.nifcloud.com/cp/api/NiftyCreateElasticLoadBalancer.htm
                                           #if use the DHCP delete this
                     'NetworkId': 'string',#Connect Network.Exclusive NetworkName.
                                           #net-COMMON_GLOBAL :Common Global
@@ -120,7 +120,7 @@ def create_multi_lb(client):
                 },
             ],
             NetworkVolume=10,# Max Network Traffic.
-                             # See also https://pfs.nifcloud.com/api/rest/NiftyCreateElasticLoadBalancer.htm
+                             # See also https://docs.nifcloud.com/cp/api/NiftyCreateElasticLoadBalancer.htm
         )
         """
         client.nifty_create_elastic_load_balancer(

--- a/python/example_code/create-rdp.py
+++ b/python/example_code/create-rdp.py
@@ -175,7 +175,7 @@ def create_rdb(client,pvlanid):
     try:
         """
         client.create_db_instance(
-            # Master Document https://pfs.nifcloud.com/api/rdb/CreateDBInstance.htm
+            # Master Document https://docs.nifcloud.com/rdb/api/CreateDBInstance.htm
             # Accounting
             # '1':Monthly
             # '2':Payper(Default)

--- a/python/example_code/get-multilb.py
+++ b/python/example_code/get-multilb.py
@@ -149,7 +149,7 @@ def get_multi_lb(client):
                 ]
             },
             # Search Filter
-            # https://pfs.nifcloud.com/api/rest/NiftyDescribeElasticLoadBalancers.htm
+            # https://docs.nifcloud.com/cp/api/NiftyDescribeElasticLoadBalancers.htm
             Filter=[
                 {
                     'ListOfRequestValue': [

--- a/python/example_code/nifcloud-basic-demo.py
+++ b/python/example_code/nifcloud-basic-demo.py
@@ -243,7 +243,7 @@ def create_instance(client):
             ImageId='string',   #OS Image Name
             InstanceId='string',#Server Name
             InstanceType="",#Server Type
-                            #see also https://pfs.nifcloud.com/api/rest/RunInstances.htm
+                            #see also https://docs.nifcloud.com/cp/api/RunInstances.htm
             KeyName='string',#SSH Key Name
             License=[#License Infomation.see also https://pfs.nifcloud.com/service/licence_ms.htm
                 {#No.1 License Info
@@ -263,7 +263,7 @@ def create_instance(client):
             NetworkInterface=[#Network Config.
                 {#Full argument
                     'IpAddress': 'string',#See also NetworkInterface.n.IpAddress in
-                                          #https://pfs.nifcloud.com/api/rest/RunInstances.htm
+                                          #https://docs.nifcloud.com/cp/api/RunInstances.htm
                                           #if use the DHCP delete this
                     'NetworkId': 'string',#Connect Network
                                           #net-COMMON_GLOBAL :Common Global

--- a/python/example_code/update-multilb.py
+++ b/python/example_code/update-multilb.py
@@ -56,7 +56,7 @@ def update_multi_lb(client):
                                    #2:Payper(Default)
             ElasticLoadBalancerNameUpdate='string' # Name After change
             NetworkVolumeUpdate=10,# Max Network Traffic.
-             # See also https://pfs.nifcloud.com/api/rest/NiftyCreateElasticLoadBalancer.htm
+             # See also https://docs.nifcloud.com/cp/api/NiftyCreateElasticLoadBalancer.htm
         )
         """
         client.nifty_update_elastic_load_balancer(

--- a/python/example_code/update_connectNW.py
+++ b/python/example_code/update_connectNW.py
@@ -68,7 +68,7 @@ def update_private_network(client, server_name):
                     #Select Setting Network.Exclusive NetwokId
                     'NetworkName'  : 'string',
                     #See also NetworkInterface.n.IpAddress in
-                    #https://pfs.nifcloud.com/api/rest/NiftyUpdateInstanceNetworkInterfaces.htm
+                    #https://docs.nifcloud.com/cp/api/NiftyUpdateInstanceNetworkInterfaces.htm
                     'IpAddress'    : 'string',
                 },
             ],

--- a/python/example_code/update_serverspec.py
+++ b/python/example_code/update_serverspec.py
@@ -65,7 +65,7 @@ def update_instance_attr(client, server_name):
             Attribute=string,
             # Update Value
             # See also
-            # https://pfs.nifcloud.com/api/rest/ModifyInstanceAttribute.htm
+            # https://docs.nifcloud.com/cp/api/ModifyInstanceAttribute.htm
             Value='string',
             # Reboot Option
             # force:Force reboot

--- a/terraform/example_code/cdp_fw/server.tf
+++ b/terraform/example_code/cdp_fw/server.tf
@@ -16,7 +16,7 @@ resource "nifcloud_instance" "websrv" {
   security_group = nifcloud_security_group.websrvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting
@@ -62,7 +62,7 @@ resource "nifcloud_instance" "appsrv" {
   # show file firewall.tf
   security_group = nifcloud_security_group.appsrvfw.group_name
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
   # Accounting
   #1:Monthly
@@ -102,7 +102,7 @@ resource "nifcloud_instance" "dbsrv" {
   # show file firewall.tf
   security_group = nifcloud_security_group.dbsrvfw.group_name
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
   # Accounting
   #1:Monthly

--- a/terraform/example_code/cdp_multi_layer/server.tf
+++ b/terraform/example_code/cdp_multi_layer/server.tf
@@ -16,7 +16,7 @@ resource "nifcloud_instance" "websrv" {
   security_group = nifcloud_security_group.websrvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting
@@ -73,7 +73,7 @@ resource "nifcloud_instance" "dbsrv" {
   # show file firewall.tf
   security_group = nifcloud_security_group.dbsrvfw.group_name
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
   # Accounting
   #1:Monthly

--- a/terraform/example_code/cdp_multi_lb_private/multiloadbalancer.tf
+++ b/terraform/example_code/cdp_multi_lb_private/multiloadbalancer.tf
@@ -1,6 +1,6 @@
 # Multi Loadbarancer Config
 resource "nifcloud_elb" "elb" {
-  # see https://pfs.nifcloud.com/api/rest/NiftyCreateElasticLoadBalancer.htm
+  # see https://docs.nifcloud.com/cp/api/NiftyCreateElasticLoadBalancer.htm
   # Multi Loadbarancer name
   elb_name          = "elb"
   # memo

--- a/terraform/example_code/cdp_multi_lb_private/server.tf
+++ b/terraform/example_code/cdp_multi_lb_private/server.tf
@@ -16,7 +16,7 @@ resource "nifcloud_instance" "srv1" {
  # security_group = nifcloud_security_group.lan01fw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting
@@ -59,7 +59,7 @@ resource "nifcloud_instance" "srv2" {
   security_group = nifcloud_security_group.lan02srvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting
@@ -102,7 +102,7 @@ resource "nifcloud_instance" "srv3" {
   security_group = nifcloud_security_group.lan02srvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting

--- a/terraform/example_code/cdp_nas/server.tf
+++ b/terraform/example_code/cdp_nas/server.tf
@@ -16,7 +16,7 @@ resource "nifcloud_instance" "srv1" {
   security_group = nifcloud_security_group.srvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting
@@ -60,7 +60,7 @@ resource "nifcloud_instance" "srv2" {
   # show file firewall.tf
   security_group = nifcloud_security_group.srvfw.group_name
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
   # Accounting
   #1:Monthly

--- a/terraform/example_code/cdp_redundantize/server.tf
+++ b/terraform/example_code/cdp_redundantize/server.tf
@@ -16,7 +16,7 @@ resource "nifcloud_instance" "srv1" {
   security_group = nifcloud_security_group.srvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting
@@ -60,7 +60,7 @@ resource "nifcloud_instance" "srv2" {
   # show file firewall.tf
   security_group = nifcloud_security_group.srvfw.group_name
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
   # Accounting
   #1:Monthly

--- a/terraform/example_code/cdp_router_proxy/server.tf
+++ b/terraform/example_code/cdp_router_proxy/server.tf
@@ -36,7 +36,7 @@ resource "nifcloud_instance" "srv" {
   security_group = nifcloud_security_group.srvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting

--- a/terraform/example_code/cdp_sorrypage/1/server.tf
+++ b/terraform/example_code/cdp_sorrypage/1/server.tf
@@ -16,7 +16,7 @@ resource "nifcloud_instance" "srv1" {
   security_group = nifcloud_security_group.srvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting
@@ -65,7 +65,7 @@ resource "nifcloud_instance" "srv2" {
   security_group = nifcloud_security_group.srvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting

--- a/terraform/example_code/cdp_sorrypage/2/multiloadbalancer.tf
+++ b/terraform/example_code/cdp_sorrypage/2/multiloadbalancer.tf
@@ -1,6 +1,6 @@
 # Multi Loadbarancer Config
 resource "nifcloud_elb" "elb" {
-  # see https://pfs.nifcloud.com/api/rest/NiftyCreateElasticLoadBalancer.htm
+  # see https://docs.nifcloud.com/cp/api/NiftyCreateElasticLoadBalancer.htm
   # Multi Loadbarancer name
   elb_name          = "elb"
   # memo

--- a/terraform/example_code/cdp_sorrypage/2/server.tf
+++ b/terraform/example_code/cdp_sorrypage/2/server.tf
@@ -16,7 +16,7 @@ resource "nifcloud_instance" "srv1" {
   security_group = nifcloud_security_group.srvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting
@@ -65,7 +65,7 @@ resource "nifcloud_instance" "srv2" {
   security_group = nifcloud_security_group.srvfw.group_name
 
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "c-medium"
 
   # Accounting

--- a/terraform/example_code/vpn/east-1-vpn.tf
+++ b/terraform/example_code/vpn/east-1-vpn.tf
@@ -1,6 +1,6 @@
 resource "nifcloud_vpn_gateway" "e13vpngw" {
   provider = nifcloud.east1
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateVpnGateway.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateVpnGateway.htm
   # Accounting
   #1:Monthly
   #2:Payper

--- a/terraform/example_code/vpn/east-1-vpngw.tf
+++ b/terraform/example_code/vpn/east-1-vpngw.tf
@@ -1,7 +1,7 @@
 # ------- VPN Connection Config ------------------------
 resource "nifcloud_customer_gateway" "e13tow12custgw" {
   provider = nifcloud.east1
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateCustomerGateway.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateCustomerGateway.htm
   # Cosuter Gateway Name
   name                = "e13tow12custgw"
   # Target Global IP for establishing a VPN Connection 
@@ -16,7 +16,7 @@ resource "nifcloud_customer_gateway" "e13tow12custgw" {
 
 resource "nifcloud_vpn_connection" "e13tow12connection" {
   provider = nifcloud.east1
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateVpnConnection.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateVpnConnection.htm
   # memo
   description                                          = "e13tow12connection"
   # VPN Connection Type.
@@ -74,7 +74,7 @@ resource "nifcloud_vpn_connection" "e13tow12connection" {
 
 resource "nifcloud_customer_gateway" "e13tow21custgw" {
   provider = nifcloud.east1
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateCustomerGateway.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateCustomerGateway.htm
   # Cosuter Gateway Name
   name                = "e13tow21custgw"
   # Target Global IP for establishing a VPN Connection 
@@ -89,7 +89,7 @@ resource "nifcloud_customer_gateway" "e13tow21custgw" {
 
 resource "nifcloud_vpn_connection" "e13tow21connection" {
   provider = nifcloud.east1
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateVpnConnection.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateVpnConnection.htm
   # memo
   description                                          = "tow21connection"
   # VPN Connection Type.

--- a/terraform/example_code/vpn/west-1-vpn.tf
+++ b/terraform/example_code/vpn/west-1-vpn.tf
@@ -1,6 +1,6 @@
 resource "nifcloud_vpn_gateway" "w12vpngw" {
   provider = nifcloud.west1
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateVpnGateway.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateVpnGateway.htm
   # Accounting
   #1:Monthly
   #2:Payper

--- a/terraform/example_code/vpn/west-1-vpngw.tf
+++ b/terraform/example_code/vpn/west-1-vpngw.tf
@@ -1,7 +1,7 @@
 # --------------- VPN Connection Config ------------------
 resource "nifcloud_customer_gateway" "toe13custgw" {
   provider = nifcloud.west1
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateCustomerGateway.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateCustomerGateway.htm
   # Cosuter Gateway Name
   name                = "toe13custgw"
   # Target Global IP for establishing a VPN Connection 
@@ -16,7 +16,7 @@ resource "nifcloud_customer_gateway" "toe13custgw" {
 
 resource "nifcloud_vpn_connection" "toe13connection" {
   provider = nifcloud.west1
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateVpnConnection.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateVpnConnection.htm
   # memo
   description                                          = "toe13connection"
   # VPN Connection Type.

--- a/terraform/example_code/vpn/west-2-vpn.tf
+++ b/terraform/example_code/vpn/west-2-vpn.tf
@@ -1,6 +1,6 @@
 resource "nifcloud_vpn_gateway" "w21vpngw" {
   provider = nifcloud.west2
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateVpnGateway.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateVpnGateway.htm
   # Accounting
   #1:Monthly
   #2:Payper

--- a/terraform/example_code/vpn/west-2-vpngw.tf
+++ b/terraform/example_code/vpn/west-2-vpngw.tf
@@ -1,7 +1,7 @@
 # --------------- VPN Connection Config ------------------
 resource "nifcloud_customer_gateway" "e21toe13custgw" {
   provider = nifcloud.west2
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateCustomerGateway.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateCustomerGateway.htm
   # Cosuter Gateway Name
   name                = "e21toe13custgw"
   # Target Global IP for establishing a VPN Connection 
@@ -16,7 +16,7 @@ resource "nifcloud_customer_gateway" "e21toe13custgw" {
 
 resource "nifcloud_vpn_connection" "e21toe13connection" {
   provider = nifcloud.west2
-  # Base Document https://pfs.nifcloud.com/api/rest/CreateVpnConnection.htm
+  # Base Document https://docs.nifcloud.com/cp/api/CreateVpnConnection.htm
   # memo
   description                                          = "e21toe13connection"
   # VPN Connection Type.

--- a/terraform/example_code/web-db/mlb.tf
+++ b/terraform/example_code/web-db/mlb.tf
@@ -1,6 +1,6 @@
 # Multi Loadbarancer sample
 resource "nifcloud_elb" "web001" {
-  # see https://pfs.nifcloud.com/api/rest/NiftyCreateElasticLoadBalancer.htm
+  # see https://docs.nifcloud.com/cp/api/NiftyCreateElasticLoadBalancer.htm
   # Multi Loadbarancer name
   elb_name          = "web001"
   # memo

--- a/terraform/example_code/web-db/rdb.tf
+++ b/terraform/example_code/web-db/rdb.tf
@@ -1,6 +1,6 @@
 # RDB sample config
 resource "nifcloud_db_instance" "db001" {
-  # Base Document https://pfs.nifcloud.com/api/rdb/CreateDBInstance.htm
+  # Base Document https://docs.nifcloud.com/rdb/api/CreateDBInstance.htm
   # -- Basic config --
   #1:Monthly
   #2:Payper
@@ -88,7 +88,7 @@ resource "nifcloud_db_instance" "db001" {
   # apply immediate for change parameter at apply.
   # if this parameter false. config apply in maitenance period.
   # See also "ApplyImmediately" in 
-  # https://pfs.nifcloud.com/api/rdb/ModifyDBInstance.htm
+  # https://docs.nifcloud.com/rdb/api/ModifyDBInstance.htm
   apply_immediately              = true
   # --- Terrfrom Parameter ---
   # bakcup in destory
@@ -100,7 +100,7 @@ resource "nifcloud_db_instance" "db001" {
 }
 
 resource "nifcloud_db_parameter_group" "db001param" {
-  # Base Document https://pfs.nifcloud.com/api/rdb/CreateDBParameterGroup.htm
+  # Base Document https://docs.nifcloud.com/rdb/api/CreateDBParameterGroup.htm
   # Config Name
   name        = "db001param"
   # Database Parameter Family name

--- a/terraform/example_code/web-db/server.tf
+++ b/terraform/example_code/web-db/server.tf
@@ -12,7 +12,7 @@ resource "nifcloud_instance" "web001" {
   # show file firewall.tf
   security_group = nifcloud_security_group.webfw.group_name
   # Server size.
-  # https://pfs.nifcloud.com/api/rest/RunInstances.htm
+  # https://docs.nifcloud.com/cp/api/RunInstances.htm
   instance_type = "small"
   # Accounting
   #1:Monthly
@@ -92,7 +92,7 @@ resource "nifcloud_volume" "commonserver" {
   # Disk Nmae
   volume_id       = "comdisk01"
   # Disk Type
-  # See also diskType at https://pfs.nifcloud.com/api/rest/DescribeVolumes.htm
+  # See also diskType at https://docs.nifcloud.com/cp/api/DescribeVolumes.htm
   disk_type       = "High-Speed Storage B"
   # Connect Server ID
   instance_id     = nifcloud_instance.commonserver.instance_id

--- a/terraform/example_code/web-db/static_ip.tf
+++ b/terraform/example_code/web-db/static_ip.tf
@@ -1,5 +1,5 @@
 # Static IP sample
-# see https://pfs.nifcloud.com/api/rest/AllocateAddress.htm
+# see https://docs.nifcloud.com/cp/api/AllocateAddress.htm
 resource "nifcloud_elastic_ip" "web001" {
   # true :Private IP
   # false:Global IP


### PR DESCRIPTION
In October 2024, the documentation site pfs.nifcloud.com/api/ was moved to docs.nifcloud.com.

Therefore, we have updated the URLs listed in the samples.